### PR TITLE
fix: running 'docker logs xxxx' does not decode utf-8 chars but produces ????? instead

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,10 @@
                         <configuration>
                             <image>
                                 <name>ghcr.io/mpalourdio/mpalourd-ai:latest</name>
+                                <env>
+                                    <!-- needed because docker logs xxx returns some ???? -->
+                                    <LC_ALL>en_US.UTF-8</LC_ALL>
+                                </env>
                             </image>
                         </configuration>
                         <executions>


### PR DESCRIPTION
Maybe related to https://github.com/paketo-buildpacks/native-image/issues/344 or https://github.com/paketo-buildpacks/bellsoft-liberica/issues/118 or https://github.com/oracle/graal/issues/9879

Who knows ?